### PR TITLE
Add test coverage for sanitizeFilename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+

--- a/package.json
+++ b/package.json
@@ -20,10 +20,11 @@
     "url": "https://github.com/WhiteByeBye/picgo-plugin-123pan/issues"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha \"tests/**/*.test.js\""
   },
   "dependencies": {},
   "devDependencies": {
-    "picgo": "^1.5.0"
+    "picgo": "^1.5.0",
+    "mocha": "^10.2.0"
   }
-} 
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1385,10 +1385,13 @@ module.exports = (ctx) => {
         ]
     }
 
-    return {
+return {
         uploader: '123pan',
         register,
         guiMenu,    // Add guiMenu for GUI features
         commands    // Add keyboard shortcuts
     };
 };
+
+// Export utility functions for testing purposes
+module.exports.sanitizeFilename = sanitizeFilename;

--- a/tests/sanitizeFilename.test.js
+++ b/tests/sanitizeFilename.test.js
@@ -1,0 +1,9 @@
+const assert = require('assert');
+const plugin = require('../src/index.js');
+
+describe('sanitizeFilename', function() {
+  it('should sanitize invalid characters', function() {
+    const result = plugin.sanitizeFilename('inva|id:name?.png');
+    assert.strictEqual(result, 'inva_id_name_.png');
+  });
+});


### PR DESCRIPTION
## Summary
- add mocha tests
- expose `sanitizeFilename` for tests
- configure npm test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fefd22b208321a810803382e5ff1c