### PR TITLE
Fix folder upload

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -216,7 +216,9 @@ async function createFile(ctx, accessToken, parentFileID, filename, etag, size) 
     };
 
     const data = JSON.stringify({
+        // Support both parameter names in case the API changes
         parentFileID: parentFileID,
+        parentFileId: parentFileID,
         filename: filename,
         etag: etag,
         size: size,


### PR DESCRIPTION
## Summary
- include both `parentFileID` and `parentFileId` when creating a file so uploads go to the desired folder

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683ff9abb3bc8321a0be3ede6793ae71